### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/nam-hle/nadle/security/code-scanning/1](https://github.com/nam-hle/nadle/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs basic CI tasks (e.g., installing dependencies, building, and testing), it only requires `contents: read` permissions. This block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
